### PR TITLE
Refactor: Use Obsidian Platform API

### DIFF
--- a/packages/obsidian-plugin/scripts/link.ts
+++ b/packages/obsidian-plugin/scripts/link.ts
@@ -4,43 +4,46 @@ import { join, resolve } from "node:path";
 /**
  * This development script creates a symlink to the plugin in the Obsidian vault's plugin directory. This allows you to
  * develop the plugin in the repository and see the changes in Obsidian without having to manually copy the files.
- * 
- * It is not included in the plugin itself. It is only used to setup development.
- * 
+ *
+ * This function is not included in the plugin itself. It is only used to set up local development.
+ *
  * Usage: `bun scripts/link.ts <path_to_obsidian_vault>`
  * @returns {Promise<void>}
  */
 async function main() {
   const args = process.argv.slice(2);
   if (args.length < 1) {
-    console.error("Usage: bun scripts/link.ts <path_to_obsidian_vault>");
+    console.error(
+      "Usage: bun scripts/link.ts <path_to_obsidian_vault_config_folder>",
+    );
     process.exit(1);
   }
-  const vaultPath = args[0];
 
-  const manifestPath = resolve(__dirname, "../manifest.json");
-  const file = Bun.file(manifestPath);
+  const vaultConfigPath = args[0];
+  const projectRootDirectory = resolve(__dirname, "../../..");
+  const pluginManifestPath = resolve(projectRootDirectory, "manifest.json");
+  const pluginsDirectoryPath = join(vaultConfigPath, "plugins");
+
+  const file = Bun.file(pluginManifestPath);
   const manifest = await file.json();
 
-  const pluginsPath = join(vaultPath, ".obsidian", "plugins");
   const pluginName = manifest.id;
-  const sourcePath = resolve(__dirname, "..");
   console.log(
-    `Creating symlink to ${sourcePath} for plugin ${pluginName} in ${pluginsPath}`,
+    `Creating symlink to ${projectRootDirectory} for plugin ${pluginName} in ${pluginsDirectoryPath}`,
   );
 
-  if (!existsSync(pluginsPath)) {
-    mkdirSync(pluginsPath, { recursive: true });
+  if (!existsSync(pluginsDirectoryPath)) {
+    mkdirSync(pluginsDirectoryPath, { recursive: true });
   }
 
-  const targetPath = join(pluginsPath, pluginName);
+  const targetPath = join(pluginsDirectoryPath, pluginName);
 
   if (existsSync(targetPath)) {
     console.log("Symlink already exists.");
     return;
   }
 
-  symlinkSync(sourcePath, targetPath, "dir");
+  symlinkSync(projectRootDirectory, targetPath, "dir");
   console.log("Symlink created successfully.");
 
   console.log(

--- a/packages/obsidian-plugin/src/features/mcp-server-install/services/status.ts
+++ b/packages/obsidian-plugin/src/features/mcp-server-install/services/status.ts
@@ -13,33 +13,6 @@ import { getPlatform } from "./install";
 const execAsync = promisify(exec);
 
 /**
- * Checks if Claude Desktop is installed by attempting to read its config file
- */
-export async function isClaudeDesktopInstalled(): Promise<boolean> {
-  const platform = process.platform;
-  const configPath =
-    platform === "win32"
-      ? path.join(
-          process.env.APPDATA || "",
-          "Claude",
-          "claude_desktop_config.json",
-        )
-      : platform === "darwin"
-        ? path.join(
-            process.env.HOME || "",
-            "Library/Application Support/Claude/claude_desktop_config.json",
-          )
-        : path.join(process.env.HOME || "", ".config/claude/config.json");
-
-  try {
-    await fsp.access(configPath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * Resolves the real path of the given file path, handling cases where the path is a symlink.
  *
  * @param filepath - The file path to resolve.

--- a/packages/obsidian-plugin/src/features/mcp-server-install/utils/openFolder.ts
+++ b/packages/obsidian-plugin/src/features/mcp-server-install/utils/openFolder.ts
@@ -1,15 +1,14 @@
 import { logger } from "$/shared/logger";
 import { exec } from "child_process";
-import { Notice } from "obsidian";
+import { Notice, Platform } from "obsidian";
 
 /**
  * Opens a folder in the system's default file explorer
  */
 export function openFolder(folderPath: string): void {
-  const platform = process.platform;
-  const command = platform === "win32"
+  const command = Platform.isWin
     ? `start "" "${folderPath}"`
-    : platform === "darwin"
+    : Platform.isMacOS
       ? `open "${folderPath}"`
       : `xdg-open "${folderPath}"`;
 


### PR DESCRIPTION
# Description

This PR includes several improvements to development setup and platform handling across the codebase:

## Development Setup
- Updates the symlink script to target the project root instead of just the plugin directory
- Improves path resolution and error messages for development setup
- Adds clearer documentation for setting up local development

## Platform Handling
- Switches to using Obsidian's built-in `Platform` utilities instead of Node's `process.platform`
- Provides more reliable platform detection in the Obsidian context
- Simplifies platform-specific code paths

## Code Cleanup
- Removes unused `isClaudeDesktopInstalled()` function as Claude config is handled elsewhere
- Improves variable naming and path handling throughout
- Better separation of concerns in platform-specific code

# Testing
- [ ] Tested symlink creation on Windows
- [x] Tested symlink creation on MacOS
- [x] Verified folder opening works on all platforms
- [x] Confirmed plugin installation still works correctly

These changes make the codebase more maintainable and provide a better development experience while simplifying platform-specific handling.