### PR TITLE
Fix example for editing front matter fields in patch_vault_file

### DIFF
--- a/packages/obsidian-plugin/docs/openapi.yaml
+++ b/packages/obsidian-plugin/docs/openapi.yaml
@@ -315,7 +315,7 @@ paths:
 
         - `Operation`: `replace`
         - `TargetType`: `frontmatter`
-        - `Target`: `beep`
+        - `Target`: `alpha`
         - with the request body `2`
 
         If you're setting a frontmatter field that might not already exist
@@ -326,7 +326,7 @@ paths:
         You may find using a `Content-Type` of `application/json` to be
         particularly useful in the case of frontmatter since frontmatter
         fields' values are JSON data, and the API can be smarter about
-        interpreting yoru `prepend` or `append` requests if you specify
+        interpreting your `prepend` or `append` requests if you specify
         your data as JSON (particularly when appending, for example,
         list items).
       parameters:


### PR DESCRIPTION
Fix example for editing front matter fields, hoping that Claude will then understand the patch_vault_file tool properly.

I was using the `patch_vault_file` tool from Claude desktop and got errors like this:

Message from client: 

```json
    {
        "method": "tools/call",
        "params": {
            "name": "patch_vault_file",
            "arguments": {
                "content": "remote_possible: \"Remote-Optionen möglich\"\nurl: https://jobs.biontech.com/job/Mainz-HR-Data-Analyst-Scientist-%28mwd%29-RP-55116/1202835801/",
                "filename": "Jobs/BioNTech - HR Data Analyst Scientist.md",
                "operation": "replace",
                "target": "remote_possible: \"Remote-Optionen möglichurl:\n  https://jobs.biontech.com/job/Mainz-HR-Data-Analyst-Scientist-%28mwd%29-RP-55\\\n  116/1202835801/\"",
                "targetType": "frontmatter"
            }
        },
        "jsonrpc": "2.0",
        "id": 52
    }
```

Message from server: 

```json
    {
        "jsonrpc": "2.0",
        "id": 52,
        "error": {
            "code": -32603,
            "message": "MCP error -32603: Header 'Target' has invalid value: 'remote_possible: \"Remote-Optionen möglichurl:\n  https://jobs.biontech.com/job/Mainz-HR-Data-Analyst-Scientist-%28mwd%29-RP-55\\\n  116/1202835801/\"'"
        }
    }
```

Here it should replace only a single frontmatter field and somehow includes multiple lines.

I have given Claude extra instructions with the (fixed) example from openapi.yaml and that fixed the problem.

I didn't bother to make this problem reproducible, sorry.