### PR TITLE
feat: support OBSIDIAN_REST_API_PORT environment variable

### DIFF
--- a/packages/mcp-server/src/shared/makeRequest.ts
+++ b/packages/mcp-server/src/shared/makeRequest.ts
@@ -4,7 +4,10 @@ import { logger } from "./logger";
 
 // Default to HTTPS port, fallback to HTTP if specified
 const USE_HTTP = process.env.OBSIDIAN_USE_HTTP === "true";
-const PORT = USE_HTTP ? 27123 : 27124;
+const DEFAULT_PORT = USE_HTTP ? 27123 : 27124;
+const PORT = process.env.OBSIDIAN_REST_API_PORT
+  ? parseInt(process.env.OBSIDIAN_REST_API_PORT, 10)
+  : DEFAULT_PORT;
 const PROTOCOL = USE_HTTP ? "http" : "https";
 const HOST = process.env.OBSIDIAN_HOST || "127.0.0.1";
 export const BASE_URL = `${PROTOCOL}://${HOST}:${PORT}`;


### PR DESCRIPTION
Adds support for configuring the REST API port via the `OBSIDIAN_REST_API_PORT` environment variable.

This enables running multiple Obsidian vaults simultaneously, each with their own MCP server instance on different ports.

**Usage:**
```json
{
  "mcpServers": {
    "vault-a": {
      "command": ".../mcp-server",
      "env": {
        "OBSIDIAN_API_KEY": "...",
        "OBSIDIAN_REST_API_PORT": "27124"
      }
    },
    "vault-b": {
      "command": ".../mcp-server",
      "env": {
        "OBSIDIAN_API_KEY": "...",
        "OBSIDIAN_REST_API_PORT": "27125"
      }
    }
  }
}
```

Closes #40