### PR TITLE
fix(mcp-server): support configurable Local REST API port

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -41,7 +41,12 @@ bun run build
 
 ### Configuration
 
-Server configuration is managed through Claude Desktop's config file:
+Server configuration is managed through Claude Desktop's config file.
+
+Port resolution order is:
+1. `--port <value>` or `--port=<value>` CLI argument
+2. `OBSIDIAN_PORT` environment variable
+3. Default local REST API port (`27124` for HTTPS, `27123` for HTTP)
 
 On macOS:
 
@@ -52,7 +57,8 @@ On macOS:
     "obsidian-mcp-tools": {
       "command": "/path/to/mcp-server",
       "env": {
-        "OBSIDIAN_API_KEY": "your-api-key"
+        "OBSIDIAN_API_KEY": "your-api-key",
+        "OBSIDIAN_PORT": "27124"
       }
     }
   }

--- a/packages/mcp-server/src/shared/makeRequest.ts
+++ b/packages/mcp-server/src/shared/makeRequest.ts
@@ -2,10 +2,37 @@ import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { type, type Type } from "arktype";
 import { logger } from "./logger";
 
-// Default to HTTPS port, fallback to HTTP if specified
+function parsePort(raw: string | undefined): number | undefined {
+  if (!raw || !/^\d+$/.test(raw)) {
+    return undefined;
+  }
+
+  const port = Number(raw);
+  return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : undefined;
+}
+
+function resolvePortFromArgs(argv: string[]): number | undefined {
+  const portArg = argv.find((arg) => arg.startsWith("--port="));
+  if (portArg) {
+    return parsePort(portArg.split("=")[1]);
+  }
+
+  const portFlagIndex = argv.findIndex((arg) => arg === "--port");
+  if (portFlagIndex >= 0) {
+    return parsePort(argv[portFlagIndex + 1]);
+  }
+
+  return undefined;
+}
+
+// Default to HTTPS port, fallback to HTTP if specified.
+// Override order: --port > OBSIDIAN_PORT > protocol default.
 const USE_HTTP = process.env.OBSIDIAN_USE_HTTP === "true";
-const PORT = USE_HTTP ? 27123 : 27124;
 const PROTOCOL = USE_HTTP ? "http" : "https";
+const DEFAULT_PORT = USE_HTTP ? 27123 : 27124;
+const ARG_PORT = resolvePortFromArgs(process.argv);
+const ENV_PORT = parsePort(process.env.OBSIDIAN_PORT);
+const PORT = ARG_PORT ?? ENV_PORT ?? DEFAULT_PORT;
 const HOST = process.env.OBSIDIAN_HOST || "127.0.0.1";
 export const BASE_URL = `${PROTOCOL}://${HOST}:${PORT}`;
 

--- a/packages/mcp-server/src/types/global.d.ts
+++ b/packages/mcp-server/src/types/global.d.ts
@@ -5,6 +5,8 @@ declare global {
       NODE_TLS_REJECT_UNAUTHORIZED: `${0 | 1}`;
       OBSIDIAN_API_KEY?: string;
       OBSIDIAN_USE_HTTP?: string;
+      OBSIDIAN_PORT?: string;
+      OBSIDIAN_HOST?: string;
     }
   }
 }


### PR DESCRIPTION
## Summary
- add --port and OBSIDIAN_PORT support
- keep protocol defaults (HTTPS 27124 / HTTP 27123)
- update README config examples

## Test plan
- [x] bun run check
- [x] manual run with --port and OBSIDIAN_PORT