### PR TITLE
fix: check POSIX absolute path before Win32 in resolveSymlinks

### DIFF
--- a/packages/obsidian-plugin/src/features/mcp-server-install/services/status.ts
+++ b/packages/obsidian-plugin/src/features/mcp-server-install/services/status.ts
@@ -30,14 +30,19 @@ async function resolveSymlinks(filepath: string): Promise<string> {
       let skipCount = 1; // Skip first segment by default
 
       // Handle the root segment differently for Windows vs POSIX
-      if (path.win32.isAbsolute(filepath)) {
+      // Check POSIX first: path.win32.isAbsolute() returns true for
+      // POSIX absolute paths (leading "/" is the current drive root in
+      // Win32), so checking it first would incorrectly push an empty
+      // string instead of "/" on Linux/macOS/WSL, producing a relative
+      // path that causes realpath to prepend CWD repeatedly.
+      if (path.posix.isAbsolute(filepath)) {
+        resolvedParts.push("/");
+      } else if (path.win32.isAbsolute(filepath)) {
         resolvedParts.push(parts[0]);
         if (parts[1] === "") {
           resolvedParts.push("");
           skipCount = 2; // Skip two segments for UNC paths
         }
-      } else if (path.posix.isAbsolute(filepath)) {
-        resolvedParts.push("/");
       } else {
         resolvedParts.push(parts[0]);
       }


### PR DESCRIPTION
## Summary

Fixes #36 — duplicate `/home/<user>` in server install path on Linux/macOS/WSL.

**Root cause:** `path.win32.isAbsolute()` returns `true` for POSIX absolute paths (a leading `/` is treated as the current drive root in Win32). Since it was checked first in the `if/else-if` chain, `path.posix.isAbsolute()` was never reached on non-Windows platforms. This caused the root segment to be set to `""` instead of `"/"`, producing a relative path. `realpath` then resolved it against CWD, prepending the home directory on every path component — and compounding with each settings panel open or install attempt.

**Fix:** Swap the `if/else-if` order so `path.posix.isAbsolute()` is checked first. This is a one-line logic change (plus explanatory comments) with no behavioral impact on Windows, where `path.posix.isAbsolute()` returns `false` for drive-letter paths like `C:\...`.

### Note on existing PRs

PRs #45 and #52 address the same issue with a post-hoc `removeDuplicatePathSegments()` function. This PR instead fixes the root cause directly, avoiding the need for path deduplication heuristics.

## Test plan

- [ ] Verify server install works on Linux/WSL with a vault path like `/home/user/vault`
- [ ] Verify server install still works on Windows with drive-letter paths
- [ ] Verify server install still works on macOS
- [ ] Verify symlinked vault paths still resolve correctly